### PR TITLE
Fix WebSocket port conversion in NFC reader

### DIFF
--- a/nfc-reader/nfc-reader.ino
+++ b/nfc-reader/nfc-reader.ino
@@ -30,7 +30,7 @@ void setup() {
   Serial.println(" connected!");
 
   // Initialize WebSocket connection
-  webSocket.beginSSL(SERVER_URL, atoi(SERVER_PORT), "/");
+  webSocket.beginSSL(SERVER_URL, SERVER_PORT.toInt(), "/");
   webSocket.onEvent([](WStype_t type, uint8_t * payload, size_t length) {
     switch(type) {
       case WStype_CONNECTED:


### PR DESCRIPTION
## Summary
- convert `SERVER_PORT` String to int before passing to `WebSocketsClient.beginSSL`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_b_684d97f23a8c832e98d8fa150473fd14