### PR TITLE
Improve project README and example env file

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+KEY_PATH=/path/to/key.pem
+CERT_PATH=/path/to/cert.pem
+PORT=3000

--- a/README.md
+++ b/README.md
@@ -1,1 +1,43 @@
-# concorde-full
+# Concorde Escape Room Controller
+
+This repository contains all code for a simple WebSocket-based server and a companion NFC reader used in an escape room setting.
+
+```
+concorde-full/
+├── concorde-controller/  # Node.js WebSocket server
+├── nfc-reader/           # ESP8266/PN532 based NFC reader project
+```
+
+## Getting Started
+
+### Server Setup
+
+The server lives in `concorde-controller`. Install dependencies with npm and start the server:
+
+```bash
+cd concorde-controller
+npm install
+node index.js
+```
+
+The server requires the following environment variables (see `.env.example`):
+
+- `KEY_PATH` – path to your TLS private key
+- `CERT_PATH` – path to the TLS certificate
+- `PORT` – port number to listen on
+
+Create a `.env` file with these values before starting the server.
+
+### NFC Reader
+
+The `nfc-reader` folder contains an Arduino sketch (`nfc-reader.ino`) built for an ESP8266 and PN532 module. Compile and flash it using the Arduino IDE or PlatformIO. The sketch expects a `secrets.h` file (not included) defining Wi‑Fi credentials and server connection details.
+
+```
+#define WIFI_SSID "your-ssid"
+#define WIFI_PASSWORD "your-password"
+#define SERVER_URL "your.server"
+#define SERVER_PORT "3000"
+```
+
+Build and upload the sketch to your microcontroller, then open the serial monitor to verify that it connects.
+


### PR DESCRIPTION
## Summary
- document repository purpose and directory layout
- add server setup instructions with env vars
- document building the NFC reader sketch and the required `secrets.h`
- provide `.env.example` placeholders

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684d984a63fc832e97d1d2232b5799b5