### PR TITLE
Add env var checks and tests

### DIFF
--- a/concorde-controller/index.js
+++ b/concorde-controller/index.js
@@ -5,6 +5,14 @@ import dotenv from 'dotenv';
 
 dotenv.config()
 
+const requiredVars = ['KEY_PATH', 'CERT_PATH', 'PORT'];
+for (const name of requiredVars) {
+  if (!process.env[name]) {
+    console.error(`Missing environment variable: ${name}`);
+    process.exit(1);
+  }
+}
+
 const options = {
   key: fs.readFileSync(process.env.KEY_PATH),
   cert: fs.readFileSync(process.env.CERT_PATH),

--- a/concorde-controller/jest.config.cjs
+++ b/concorde-controller/jest.config.cjs
@@ -1,0 +1,3 @@
+module.exports = {
+  testEnvironment: 'node',
+};

--- a/concorde-controller/package.json
+++ b/concorde-controller/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,9 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "ws": "^8.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   },
   "type": "module"
 }

--- a/concorde-controller/tests/envVars.test.cjs
+++ b/concorde-controller/tests/envVars.test.cjs
@@ -1,0 +1,28 @@
+const { spawnSync } = require('child_process');
+const path = require('path');
+
+function runWithEnv(env) {
+  const result = spawnSync('node', [path.join(__dirname, '../index.js')], {
+    env: { ...process.env, ...env },
+    encoding: 'utf8'
+  });
+  return result;
+}
+
+test('fails when KEY_PATH is missing', () => {
+  const { status, stderr } = runWithEnv({ KEY_PATH: undefined, CERT_PATH: 'cert', PORT: '3000' });
+  expect(status).toBe(1);
+  expect(stderr).toMatch(/Missing environment variable: KEY_PATH/);
+});
+
+test('fails when CERT_PATH is missing', () => {
+  const { status, stderr } = runWithEnv({ KEY_PATH: 'key', CERT_PATH: undefined, PORT: '3000' });
+  expect(status).toBe(1);
+  expect(stderr).toMatch(/Missing environment variable: CERT_PATH/);
+});
+
+test('fails when PORT is missing', () => {
+  const { status, stderr } = runWithEnv({ KEY_PATH: 'key', CERT_PATH: 'cert', PORT: undefined });
+  expect(status).toBe(1);
+  expect(stderr).toMatch(/Missing environment variable: PORT/);
+});


### PR DESCRIPTION
## Summary
- ensure `KEY_PATH`, `CERT_PATH` and `PORT` are present before starting server
- add Jest setup and tests for failing fast on missing env vars

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d98592124832e994c79da10bcfd3e