### PR TITLE
Add Jest tests for WebSocket registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # concorde-full
+
+This repository contains the code for the Concorde escape room project.
+
+## Testing
+
+The Node.js server under `concorde-controller` uses Jest for unit tests.
+
+Run the following commands from the `concorde-controller` directory:
+
+```bash
+npm install
+npm test
+```
+
+The test suite covers the WebSocket registration logic.

--- a/concorde-controller/__tests__/index.test.js
+++ b/concorde-controller/__tests__/index.test.js
@@ -1,0 +1,32 @@
+import { registerSocket } from '../index.js';
+
+describe('registerSocket', () => {
+  test('register event sets properties and notifies setup sockets', () => {
+    const socket = { send: jest.fn() };
+    const setup1 = { role: 'setup', send: jest.fn() };
+    const setup2 = { role: 'setup', send: jest.fn() };
+    const wss = { clients: new Set([setup1, setup2]) };
+
+    registerSocket(socket, 'abc', 'register', wss);
+
+    const msg = JSON.stringify({ event: 'register_success', id: 'abc' });
+    expect(socket.uid).toBe('abc');
+    expect(socket.role).toBe('register');
+    expect(socket.send).toHaveBeenCalledWith(msg);
+    expect(setup1.send).toHaveBeenCalledWith(msg);
+    expect(setup2.send).toHaveBeenCalledWith(msg);
+  });
+
+  test('setup event only notifies the socket itself', () => {
+    const socket = { send: jest.fn() };
+    const setup1 = { role: 'setup', send: jest.fn() };
+    const wss = { clients: new Set([setup1]) };
+
+    registerSocket(socket, 'def', 'setup', wss);
+
+    const msg = JSON.stringify({ event: 'setup_success', id: 'def' });
+    expect(socket.role).toBe('setup');
+    expect(socket.send).toHaveBeenCalledWith(msg);
+    expect(setup1.send).not.toHaveBeenCalled();
+  });
+});

--- a/concorde-controller/index.js
+++ b/concorde-controller/index.js
@@ -22,7 +22,7 @@ server.listen(process.env.PORT, '0.0.0.0', () => {
 
 const wss = new WebSocketServer({ server });
 
-function registerSocket(socket, id, event) {
+export function registerSocket(socket, id, event, wssInstance = wss) {
   console.log(`${event}: `, id);
   socket.uid = id;
   socket.role = event;
@@ -30,7 +30,7 @@ function registerSocket(socket, id, event) {
 
   // Notify all setup sockets when a client registers successfully
   if (event === 'register') {
-    wss.clients.forEach((client) => {
+    wssInstance.clients.forEach((client) => {
       if (client.role === 'setup') {
         console.log('sending');
         client.send(message);

--- a/concorde-controller/jest.config.js
+++ b/concorde-controller/jest.config.js
@@ -1,0 +1,3 @@
+export default {
+  testEnvironment: 'node',
+};

--- a/concorde-controller/package.json
+++ b/concorde-controller/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.js",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "NODE_OPTIONS=--experimental-vm-modules jest"
   },
   "repository": {
     "type": "git",
@@ -20,6 +20,9 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "ws": "^8.18.2"
+  },
+  "devDependencies": {
+    "jest": "^29.7.0"
   },
   "type": "module"
 }


### PR DESCRIPTION
## Summary
- add Jest dev dependency and config
- export `registerSocket` to make it testable
- create unit tests for WebSocket registration logic
- document running tests

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d985b5040832e9e3c11a8873f24c0