### PR TITLE
Fix WebSocket beginSSL argument type

### DIFF
--- a/nfc-reader/nfc-reader.ino
+++ b/nfc-reader/nfc-reader.ino
@@ -30,7 +30,9 @@ void setup() {
   Serial.println(" connected!");
 
   // Initialize WebSocket connection
-  webSocket.beginSSL(SERVER_URL, SERVER_PORT.toInt(), "/");
+  // SERVER_URL is defined as a String in secrets.h, but beginSSL expects a
+  // const char*. Use c_str() to convert the String to the expected type.
+  webSocket.beginSSL(SERVER_URL.c_str(), SERVER_PORT.toInt(), "/");
   webSocket.onEvent([](WStype_t type, uint8_t * payload, size_t length) {
     switch(type) {
       case WStype_CONNECTED:


### PR DESCRIPTION
## Summary
- use `c_str()` when passing `SERVER_URL` to `beginSSL`

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_b_684d98b5cf74832ebef9105adfae2533