### PR TITLE
Handle NFC events and register reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,9 @@ The `nfc-reader` folder contains an Arduino sketch (`nfc-reader.ino`) built for 
 ```
 #define WIFI_SSID "your-ssid"
 #define WIFI_PASSWORD "your-password"
-#define SERVER_URL "your.server"
+#define SERVER_IP "your.server"
 #define SERVER_PORT "3000"
+#define READER_ID "reader-01"
 ```
 
 Build and upload the sketch to your microcontroller, then open the serial monitor to verify that it connects.

--- a/concorde-controller/index.js
+++ b/concorde-controller/index.js
@@ -69,6 +69,10 @@ wss.on('connection', (socket) => {
         });
         break;
 
+      case 'nfc':
+        console.log(`Reader with id ${data.id} just read: ${data.uuid}`);
+        break;
+
       default:
         console.log('Received event:', data.event);
         break;

--- a/nfc-reader/nfc-reader.ino
+++ b/nfc-reader/nfc-reader.ino
@@ -7,6 +7,7 @@
 
 const String ssid = WIFI_SSID;
 const String password = WIFI_PASSWORD;
+const String readerId = READER_ID;
 
 
 ///////////////////////
@@ -37,6 +38,8 @@ void setup() {
     switch(type) {
       case WStype_CONNECTED:
         Serial.println("WebSocket connected");
+        // Register this reader with the server using a predefined id
+        webSocket.sendTXT("{\"event\":\"register\",\"id\":\"" + readerId + "\"}");
         break;
       case WStype_DISCONNECTED:
         Serial.println("WebSocket disconnected");
@@ -97,7 +100,7 @@ void loop() {
 
 void sendUIDtoServer(String uid) {
   if (WiFi.status() == WL_CONNECTED && webSocket.isConnected()) {
-    String payload = "{\"uid\":\"" + uid + "\"}";
+    String payload = "{\"event\":\"nfc\",\"id\":\"" + readerId + "\",\"uuid\":\"" + uid + "\"}";
     webSocket.sendTXT(payload);
     Serial.println("UID sent over WebSocket");
   } else {


### PR DESCRIPTION
## Summary
- update README to include READER_ID in the `secrets.h` example
- allow the ESP NFC reader to register itself on connect
- emit an `nfc` event with reader id when a tag is scanned
- log NFC events on the server

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684dbf38ef70832ead9bf9fa006ccfee