### PR TITLE
Fix npm start

### DIFF
--- a/concorde-controller/package.json
+++ b/concorde-controller/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "ts-node index.ts",
+    "start": "TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm index.ts",
     "build": "tsc"
   },
   "repository": {


### PR DESCRIPTION
## Summary
- update `concorde-controller` start script to properly run with ts-node's ESM loader

## Testing
- `tsc --version`

------
https://chatgpt.com/codex/tasks/task_b_684dc4d4b264832e8cfd256f4c415fb1