### PR TITLE
Add servo start/stop on NFC scan

### DIFF
--- a/concorde-controller/index.ts
+++ b/concorde-controller/index.ts
@@ -27,6 +27,7 @@ interface ExtendedWebSocket extends WebSocket {
 }
 
 const wss = new WebSocketServer({ server });
+let servoSpinning = false;
 
 function registerSocket(socket: ExtendedWebSocket, id: string, event: string): void {
   console.log(`${event}: `, id);
@@ -79,6 +80,16 @@ wss.on('connection', (socket: ExtendedWebSocket) => {
 
       case 'nfc':
         console.log(`Reader with id ${data.id} just read: ${data.uuid}`);
+        if (data.id === 'NFC_1' && data.uuid === '04:ac:09:6a:06:1f:94') {
+          servoSpinning = !servoSpinning;
+          const event = servoSpinning ? 'start_spin' : 'stop_spin';
+          wss.clients.forEach((client) => {
+            const wsClient = client as ExtendedWebSocket;
+            if (wsClient.uid === 'SERVO_1') {
+              wsClient.send(JSON.stringify({ event, id: wsClient.uid }));
+            }
+          });
+        }
         break;
 
       default:

--- a/servo/servo.ino
+++ b/servo/servo.ino
@@ -10,6 +10,9 @@ const String ssid = WIFI_SSID;
 const String password = WIFI_PASSWORD;
 const String servoId = SERVO_ID;
 WebSocketsClient webSocket;
+bool isSpinning = false;
+int currentPos = 0;
+int stepDir = 1;
 
 void setup() {
     Serial.begin(115200);
@@ -40,6 +43,14 @@ void setup() {
         break;
       case WStype_TEXT:
         Serial.printf("WS Message: %s\n", payload);
+        if (strstr((char*)payload, "start_spin")) {
+          isSpinning = true;
+        } else if (strstr((char*)payload, "stop_spin")) {
+          isSpinning = false;
+          currentPos = 0;
+          stepDir = 1;
+          myservo.write(0);
+        }
         break;
       default:
         break;
@@ -59,15 +70,19 @@ void setup() {
 }
 
 void loop() {
-  // Sweep from 0 to 180
-  for (int pos = 0; pos <= 180; pos++) {
-    myservo.write(pos);
+  webSocket.loop();
+  if (isSpinning) {
+    myservo.write(currentPos);
+    currentPos += stepDir;
+    if (currentPos >= 180) {
+      currentPos = 180;
+      stepDir = -1;
+    } else if (currentPos <= 0) {
+      currentPos = 0;
+      stepDir = 1;
+    }
     delay(5);
-  }
-
-  // Sweep back from 180 to 0
-  for (int pos = 180; pos >= 0; pos--) {
-    myservo.write(pos);
-    delay(5);
+  } else {
+    delay(10);
   }
 }


### PR DESCRIPTION
## Summary
- toggle SERVO_1 spinning from concorde-controller when NFC_1 scans UID
- update servo sketch to react to `start_spin` and `stop_spin` messages

## Testing
- `npm run build` *(fails: cannot find module 'ws' etc.)*

------
https://chatgpt.com/codex/tasks/task_b_684dce678078832e9b0b2b30303f3e8e