### PR TITLE
Improve websocket reconnection for NFC reader

### DIFF
--- a/nfc-reader/nfc-reader.ino
+++ b/nfc-reader/nfc-reader.ino
@@ -54,6 +54,9 @@ void setup() {
     }
   });
   webSocket.setReconnectInterval(5000);
+  // Send pings periodically so we detect broken connections
+  // If two pings fail the client will disconnect and trigger a reconnect
+  webSocket.enableHeartbeat(15000, 3000, 2);
 
   // Wait until the WebSocket connection is established before proceeding
   Serial.print("Connecting to WebSocket...");


### PR DESCRIPTION
## Summary
- send WebSocket heartbeat pings from the NFC reader

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684dd6f977e8832eb7e7c31df537caa7