### PR TITLE
Enable magnet reader websocket communication

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ This repository contains all code for a simple WebSocket-based server and a comp
 concorde-full/
 ├── concorde-controller/  # TypeScript WebSocket server
 ├── nfc-reader/           # ESP8266/PN532 based NFC reader project
+├── magnet-reader/        # ESP8266 based reed switch sensor
+├── servo/                # WebSocket controllable servo example
 ```
 
 ## Getting Started
@@ -41,4 +43,21 @@ The `nfc-reader` folder contains an Arduino sketch (`nfc-reader.ino`) built for 
 ```
 
 Build and upload the sketch to your microcontroller, then open the serial monitor to verify that it connects.
+
+### Magnet Reader
+
+`magnet-reader` provides a simple reed switch sensor that reports its open/closed
+state over WebSockets. Create a `secrets.h` file with Wi‑Fi and server details
+similar to the NFC reader:
+
+```
+#define WIFI_SSID "your-ssid"
+#define WIFI_PASSWORD "your-password"
+#define SERVER_IP "your.server"
+#define SERVER_PORT "3000"
+#define MAGNET_ID "magnet-01"
+```
+
+When the reed switch changes state the sketch sends a `magnet` event to the
+Concorde controller indicating whether the cabinet is `open` or `closed`.
 

--- a/concorde-controller/src/server.ts
+++ b/concorde-controller/src/server.ts
@@ -58,6 +58,10 @@ export function startServer() {
             clients.send('register', 'SERVO_1', JSON.stringify({ event, id: 'SERVO_1' }));
           }
           break;
+        case 'magnet':
+          console.log(`Magnet ${data.id} state: ${data.state}`);
+          clients.broadcast('setup', JSON.stringify({ event: 'magnet', id: data.id, state: data.state }));
+          break;
         default:
           console.log('Received event:', data.event);
           break;

--- a/magnet-reader/magnet-reader.ino
+++ b/magnet-reader/magnet-reader.ino
@@ -1,24 +1,79 @@
+#include <ESP8266WiFi.h>
+#include <WebSocketsClient.h>
+#include "secrets.h"
+
 #define REED_PIN D5  // GPIO14
 
+WebSocketsClient webSocket;
 bool lastState = HIGH;
+
+const String ssid = WIFI_SSID;
+const String password = WIFI_PASSWORD;
+const String magnetId = MAGNET_ID;
 
 void setup() {
   pinMode(REED_PIN, INPUT_PULLUP);  // use internal pull-up
   Serial.begin(115200);
+
+  Serial.print("Connecting to WiFi...");
+  WiFi.begin(ssid, password);
+  while (WiFi.status() != WL_CONNECTED) {
+    delay(500);
+    Serial.print('.');
+  }
+  Serial.println(" connected!");
+
+  // SERVER_IP is defined as a String in secrets.h, but beginSSL expects a const char*
+  webSocket.beginSSL(SERVER_IP.c_str(), SERVER_PORT.toInt(), "/");
+  webSocket.onEvent([](WStype_t type, uint8_t * payload, size_t length) {
+    switch(type) {
+      case WStype_CONNECTED: {
+        Serial.println("WebSocket connected");
+        String payload = "{\"event\":\"register\",\"id\":\"" + magnetId + "\"}";
+        webSocket.sendTXT(payload);
+        break;
+      }
+      case WStype_DISCONNECTED:
+        Serial.println("WebSocket disconnected");
+        break;
+      case WStype_TEXT:
+        Serial.printf("WS Message: %s\n", payload);
+        break;
+      default:
+        break;
+    }
+  });
+  webSocket.setReconnectInterval(5000);
+  webSocket.enableHeartbeat(15000, 3000, 2);
+
+  Serial.print("Connecting to WebSocket...");
+  while (!webSocket.isConnected()) {
+    webSocket.loop();
+    delay(100);
+  }
+  Serial.println(" connected!");
 }
 
 void loop() {
+  webSocket.loop();
   bool currentState = digitalRead(REED_PIN);
 
   if (currentState != lastState) {
-    if (currentState == HIGH) {
-      Serial.println("Cabinet opened");
-      // send WebSocket message here
-    } else {
-      Serial.println("Cabinet closed");
-    }
+    String stateStr = currentState == HIGH ? "open" : "closed";
+    Serial.printf("Cabinet %s\n", stateStr.c_str());
+    sendStateToServer(stateStr);
     lastState = currentState;
   }
 
   delay(50); // debounce delay
+}
+
+void sendStateToServer(String state) {
+  if (WiFi.status() == WL_CONNECTED && webSocket.isConnected()) {
+    String payload = "{\"event\":\"magnet\",\"id\":\"" + magnetId + "\",\"state\":\"" + state + "\"}";
+    webSocket.sendTXT(payload);
+  } else {
+    Serial.println("WiFi/WebSocket not connected. Cannot send state.");
+    webSocket.loop();
+  }
 }


### PR DESCRIPTION
## Summary
- document magnet-reader and servo in README
- add websocket support to magnet-reader
- notify magnet state using new `magnet` event
- broadcast magnet events from the controller

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_b_684de2948eec832e8bb823cf47265ecf