### PR TITLE
Add controller tests

### DIFF
--- a/concorde-controller/package.json
+++ b/concorde-controller/package.json
@@ -4,7 +4,7 @@
   "description": "",
   "main": "index.ts",
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1",
+    "test": "node --loader ./ts-loader.mjs --test test/unit/clients.test.ts test/integration/server.test.ts",
     "start": "cross-env TS_NODE_TRANSPILE_ONLY=1 node --loader ts-node/esm index.ts",
     "build": "tsc"
   },

--- a/concorde-controller/test/integration/server.test.ts
+++ b/concorde-controller/test/integration/server.test.ts
@@ -1,0 +1,43 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { once } from 'events';
+import { WebSocket } from 'ws';
+import path from 'path';
+import { fileURLToPath } from 'url';
+import { startServer } from '../../src/server.js';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+
+function waitMessage(ws: WebSocket) {
+  return once(ws, 'message').then(([data]) => JSON.parse(data.toString()));
+}
+
+test('basic websocket workflow', async () => {
+  process.env.KEY_PATH = path.join(__dirname, '../fixtures/test-key.pem');
+  process.env.CERT_PATH = path.join(__dirname, '../fixtures/test-cert.pem');
+  process.env.PORT = '0';
+
+  const { httpServer, wss } = startServer();
+  const port = (httpServer.address() as any).port;
+  const url = `wss://localhost:${port}`;
+
+  const servo = new WebSocket(url, { rejectUnauthorized: false });
+  await once(servo, 'open');
+  servo.send(JSON.stringify({ event: 'register', id: 'SERVO_1' }));
+  await waitMessage(servo); // register success
+
+  const nfc = new WebSocket(url, { rejectUnauthorized: false });
+  await once(nfc, 'open');
+  nfc.send(JSON.stringify({ event: 'register', id: 'NFC_1' }));
+  await waitMessage(nfc); // register success
+
+  nfc.send(JSON.stringify({ event: 'nfc', id: 'NFC_1', uuid: '04:ac:09:6a:06:1f:94' }));
+  const servoMsg = await waitMessage(servo);
+  assert.equal(servoMsg.event, 'start_spin');
+
+  servo.close();
+  nfc.close();
+  await Promise.all([once(servo, 'close'), once(nfc, 'close')]);
+  wss.close();
+  httpServer.close();
+});

--- a/concorde-controller/test/types.d.ts
+++ b/concorde-controller/test/types.d.ts
@@ -1,0 +1,9 @@
+declare module 'fs';
+declare module 'https';
+declare module 'ws';
+declare module 'dotenv';
+declare module 'events';
+declare module 'path';
+declare module 'url';
+declare module 'node:test';
+declare module 'node:assert/strict';

--- a/concorde-controller/test/unit/clients.test.ts
+++ b/concorde-controller/test/unit/clients.test.ts
@@ -1,0 +1,34 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { ClientManager, ManagedWebSocket } from '../../src/clients.js';
+
+test('register and unregister clients', () => {
+  const mgr = new ClientManager();
+  const sock: any = { send: () => {} } as ManagedWebSocket;
+  mgr.register('c1', 'role', sock);
+  assert.equal(sock.id, 'c1');
+  assert.equal(sock.role, 'role');
+  (mgr as any).clients.get('role').has('c1');
+  mgr.unregister(sock);
+  assert.ok(!(mgr as any).clients.get('role')?.has('c1'));
+});
+
+test('send to single client', () => {
+  const mgr = new ClientManager();
+  let msg = '';
+  const sock: any = { send: (m: string) => { msg = m; } } as ManagedWebSocket;
+  mgr.register('c1', 'role', sock);
+  mgr.send('role', 'c1', 'hello');
+  assert.equal(msg, 'hello');
+});
+
+test('broadcast to all role clients', () => {
+  const mgr = new ClientManager();
+  const msgs: string[] = [];
+  const mkSock = () => ({ send: (m: string) => msgs.push(m) }) as ManagedWebSocket;
+  mgr.register('a', 'role', mkSock());
+  mgr.register('b', 'role', mkSock());
+  mgr.broadcast('role', 'hi');
+  assert.equal(msgs.length, 2);
+  assert.deepEqual(msgs, ['hi', 'hi']);
+});

--- a/concorde-controller/ts-loader.mjs
+++ b/concorde-controller/ts-loader.mjs
@@ -1,0 +1,18 @@
+import { readFile } from 'fs/promises';
+import ts from 'typescript';
+export async function resolve(specifier, context, defaultResolve) {
+  if (specifier.endsWith('.ts')) {
+    return { url: new URL(specifier, context.parentURL).href, shortCircuit: true };
+  }
+  return defaultResolve(specifier, context, defaultResolve);
+}
+export async function load(url, context, defaultLoad) {
+  if (url.endsWith('.ts')) {
+    const source = await readFile(new URL(url));
+    const result = ts.transpileModule(source.toString(), {
+      compilerOptions: { module: ts.ModuleKind.ESNext, target: ts.ScriptTarget.ES2020 }
+    });
+    return { format: 'module', source: result.outputText, shortCircuit: true };
+  }
+  return defaultLoad(url, context, defaultLoad);
+}

--- a/concorde-controller/tsconfig.test.json
+++ b/concorde-controller/tsconfig.test.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "outDir": "build",
+    "noImplicitAny": false,
+    "strict": false
+  },
+  "include": ["index.ts", "src/**/*.ts", "test/**/*.ts"],
+  "files": ["test/types.d.ts"]
+}


### PR DESCRIPTION
## Summary
- add a ts loader for runtime compilation
- create unit tests for the WebSocket client manager
- create integration test covering server workflow
- wire up npm test script

## Testing
- `npm test` *(fails: Cannot find package 'ws')*

------
https://chatgpt.com/codex/tasks/task_b_684dfb70aa48832e9dae7757a30b36d5